### PR TITLE
Support monoio 0.0.9, fix lifetime issues and bump version to 0.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ license = "MIT/Apache-2.0"
 name = "monoio-codec"
 readme = "README.md"
 repository = "https://github.com/monoio-rs/monoio-codec"
-version = "0.0.3"
+version = "0.0.4"
 
 [dependencies]
 bytes = {version = "1"}
-monoio = {version = "0.0.8", default_features = false, features = ["bytes"], path = "../monoio/monoio"}
+monoio = {version = "0.0.9", default_features = false, features = ["bytes"], path = "../monoio/monoio"}
 tokio-util = {version = "0.7", default_features = false, features = ["codec"]}
 
 [dev-dependencies]
-monoio = {version = "0.0.8", features = ["macros"], path = "../monoio/monoio"}
+monoio = {version = "0.0.9", features = ["macros"], path = "../monoio/monoio"}

--- a/src/framed.rs
+++ b/src/framed.rs
@@ -211,7 +211,7 @@ where
 {
     type Item = Result<Codec::Item, Codec::Error>;
 
-    type NextFuture<'a> = impl Future<Output = Option<Self::Item>> where Self: 'a;
+    type NextFuture<'a> = impl Future<Output = Option<Self::Item>> + 'a where Self: 'a;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
         Self::next_with(&mut self.io, &mut self.codec, &mut self.state)
@@ -223,14 +223,15 @@ where
     IO: AsyncWriteRent,
     Codec: Encoder<Item>,
     S: BorrowMut<WriteState>,
+    Item: 'static,
 {
     type Error = Codec::Error;
 
-    type SendFuture<'a> = impl Future<Output = Result<(), Self::Error>> where Self: 'a;
+    type SendFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
 
-    type FlushFuture<'a> = impl Future<Output = Result<(), Self::Error>> where Self: 'a;
+    type FlushFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
 
-    type CloseFuture<'a> = impl Future<Output = Result<(), Self::Error>> where Self: 'a;
+    type CloseFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
 
     fn send(&mut self, item: Item) -> Self::SendFuture<'_> {
         async move {
@@ -640,6 +641,7 @@ impl<IO, Codec, Item> Sink<Item> for Framed<IO, Codec>
 where
     IO: AsyncWriteRent,
     Codec: Encoder<Item>,
+    Item: 'static
 {
     type Error = <FramedInner<IO, Codec, RWState> as Sink<Item>>::Error;
 
@@ -675,6 +677,7 @@ impl<IO, Codec, Item> Sink<Item> for FramedWrite<IO, Codec>
 where
     IO: AsyncWriteRent,
     Codec: Encoder<Item>,
+    Item: 'static,
 {
     type Error = <FramedInner<IO, Codec, WriteState> as Sink<Item>>::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(stable_features)]
-#![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 
 mod async_codec;

--- a/tests/framed_read.rs
+++ b/tests/framed_read.rs
@@ -1,7 +1,6 @@
 // Part of the helper functions and tests are borrowed from tokio-util.
 
 #![allow(stable_features)]
-#![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 
 use std::{collections::VecDeque, io};
@@ -226,9 +225,9 @@ struct Mock {
 use monoio::buf::{IoBufMut, IoVecBufMut};
 
 impl AsyncReadRent for Mock {
-    type ReadFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> where
+    type ReadFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> + 'a where
         B: IoBufMut + 'a;
-    type ReadvFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> where
+    type ReadvFuture<'a, B> = impl std::future::Future<Output = monoio::BufResult<usize, B>> + 'a where
         B: IoVecBufMut + 'a;
 
     fn read<T: IoBufMut>(&mut self, mut buf: T) -> Self::ReadFuture<'_, T> {


### PR DESCRIPTION
Support monoio 0.0.9, fix lifetime issues and bump version to 0.0.4

```
Finished dev [unoptimized + debuginfo] target(s) in 0.03s
```

```
test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests monoio-codec

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```