### PR TITLE
feat: support SinkWithCodec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 name = "monoio-codec"
 readme = "README.md"
 repository = "https://github.com/monoio-rs/monoio-codec"
-version = "0.3.3"
+version = "0.3.4"
 
 [dependencies]
 bytes = { version = "1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,7 @@ pub mod length_delimited;
 mod sync_codec;
 
 pub use async_codec::{AsyncDecoder, AsyncEncoder};
-pub use framed::{Framed, FramedRead, FramedWrite, NextWithCodec};
+#[deprecated]
+pub use framed::StreamWithCodec as NextWithCodec;
+pub use framed::{Framed, FramedRead, FramedWrite, SinkWithCodec, StreamWithCodec};
 pub use sync_codec::{Decoded, Decoder, Encoder};


### PR DESCRIPTION
When user want to put the `Framed` into cache, but use new codec each time, there's no need to consume the Framed or FramedWrite to `map_codec` to a new one. Useful when it is not allowed to take ownership(for example, `Pooled<Framed>`).